### PR TITLE
bugfix : path may conflict with the system path

### DIFF
--- a/setpath.cmd
+++ b/setpath.cmd
@@ -1,3 +1,3 @@
-SET PATH=%PATH%;%~dp0ruby\bin;%~dp0devkit\bin;%~dp0git\bin;%~dp0Python\App;%~dp0devkit\mingw\bin;%~dp0curl\bin
+SET PATH=%~dp0ruby\bin;%~dp0devkit\bin;%~dp0git\bin;%~dp0Python\App;%~dp0devkit\mingw\bin;%~dp0curl\bin;%PATH%;
 
 set SSL_CERT_FILE=%~dp0curl\bin\cacert.pem


### PR DESCRIPTION
let portable env overwrite the system path.
see more : https://github.com/madhur/PortableJekyll/issues/6