### PR TITLE
Jekyll Console

### DIFF
--- a/setpath.cmd
+++ b/setpath.cmd
@@ -1,3 +1,12 @@
-SET PATH=%~dp0ruby\bin;%~dp0devkit\bin;%~dp0git\bin;%~dp0Python\App;%~dp0devkit\mingw\bin;%~dp0curl\bin;%PATH%;
+@echo off
+@title Portable Jekyll
 
-set SSL_CERT_FILE=%~dp0curl\bin\cacert.pem
+SET PATH=%~dp0ruby\bin;%~dp0devkit\bin;%~dp0git\bin;%~dp0Python\App;%~dp0devkit\mingw\bin;%~dp0curl\bin;%PATH%;
+SET SSL_CERT_FILE=%~dp0curl\bin\cacert.pem
+
+:: Header
+echo Welcome to Portable Jekyll
+echo.
+
+:: now bring current sessions to cmd with /k args (stay)
+call cmd /k


### PR DESCRIPTION
Just make it more portable, with console-like for Jekyll, allow Console to stay