### PR TITLE
Add ability to pass commands to Portable Jekyll

### DIFF
--- a/setpath.cmd
+++ b/setpath.cmd
@@ -8,5 +8,11 @@ SET SSL_CERT_FILE=%~dp0curl\bin\cacert.pem
 echo Welcome to Portable Jekyll
 echo.
 
-:: now bring current sessions to cmd with /k args (stay)
-call cmd /k
+:: now bring current sessions to cmd
+if [%1]==[] (
+    :: ...either with /k args (stay)
+    call cmd /k
+) else (
+    :: ...or directly call something else
+    call cmd /c %1
+)


### PR DESCRIPTION
With this change, you can still use `setpath.cmd` to open a command prompt and enter Jekyll commands, like before.

Plus, you can now pass a command which will be executed.  
This is useful to create batch files which you can simply double-click to execute something via Portable Jekyll:
### 1. Building your project with the Jekyll version from Portable Jekyll

Create a batch file in your project's folder with the following content:

```
"c:\PathToPortableJekyll\setpath.cmd" "jekyll serve"
```

Executing this batch file will use the Portable Jekyll version in the specified path to build/serve your project.

I often use batch files to run Jekyll when I need to [supply additional configuration settings](http://jekyllrb.com/docs/configuration/) and I'm too lazy to type `jekyll serve --foo bar --baz xyz` by hand each time.
### 2. Executing a Ruby script using the Ruby version from Portable Jekyll

```
call "c:\PathToPortableJekyll\setpath.cmd" "ruby c:\foo\somescript.rb"
```

A batch file with this content will terminate after execution (`cmd /k` won't), so I can call it from another batch file.  
(my use case: I have an existing batch file backing up stuff from my machine, and I needed to run [wunderlist-backup](https://github.com/bernd/wunderlist-backup) from it, so my Wunderlist data is included in the backup)
